### PR TITLE
Support for new hosted dependencies format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.2.0] - Support short format for hosted dependencies
+
+* Support for new (Dart 2.15 and later) format of defining hosted dependencies.
+See [documentation](https://dart.dev/tools/pub/dependencies#hosted-packages).
+
 ## [3.1.0] - Improved YAML formatting
 * Correct YAML output with nested arrays and structures
 

--- a/lib/src/hosted_package_dependency_spec/serializers.dart
+++ b/lib/src/hosted_package_dependency_spec/serializers.dart
@@ -34,10 +34,12 @@ extension HostedPackageDependencySpecToJson on HostedPackageDependencySpec {
   Map<String, dynamic> toJson() => <String, dynamic>{
         package: url.hasValue
             ? <String, dynamic>{
-                _Tokens.hosted: <String, dynamic>{
-                  if (name.hasValue) _Tokens.name: name.valueOr(() => ''),
-                  if (url.hasValue) _Tokens.url: url.valueOr(() => ''),
-                },
+                _Tokens.hosted: !name.hasValue && url.hasValue
+                    ? url.valueOr(() => '')
+                    : <String, dynamic>{
+                        if (name.hasValue) _Tokens.name: name.valueOr(() => ''),
+                        if (url.hasValue) _Tokens.url: url.valueOr(() => ''),
+                      },
                 if (version.hasValue)
                   _Tokens.version: version.valueOr(() => ''),
               }
@@ -71,12 +73,22 @@ HostedPackageDependencySpec _loadGenericHostedDependency(
   String package,
   Map<String, dynamic> definition,
 ) {
-  final definitionBody = definition[_Tokens.hosted] as Map<String, dynamic>;
+  final definitionBody = definition[_Tokens.hosted] as Object;
+  final String? name;
+  final String? url;
+  if (definitionBody is Map<String, dynamic>) {
+    name = definitionBody[_Tokens.name] as String;
+    url = definitionBody[_Tokens.url] as String?;
+  } else {
+    url = definitionBody as String;
+    name = null;
+  }
+
   return HostedPackageDependencySpec(
     package: package,
     version: Optional(definition[_Tokens.version] as String?),
-    name: Optional(definitionBody[_Tokens.name] as String?),
-    url: Optional(definitionBody[_Tokens.url] as String?),
+    name: Optional(name),
+    url: Optional(url),
   );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pubspec_yaml
-description: Dart library to access and manipulate content of pubpec.yaml files
-version: 3.1.0
+description: Dart library to access and manipulate content of pubspec.yaml files
+version: 3.2.0
 homepage: https://github.com/alexei-sintotski/pubspec_yaml
 
 environment:

--- a/test/dependency_specs/hosted_package_dependency_spec_test.dart
+++ b/test/dependency_specs/hosted_package_dependency_spec_test.dart
@@ -186,8 +186,8 @@ void main() {
   });
 
   group(
-      'given pubspec.yaml with dependency hosted in shot format with version spec',
-      () {
+      'given pubspec.yaml with dependency hosted in shot format '
+      'with version spec', () {
     final pubspec = PubspecYaml.loadFromYamlString(
       pubspecWithPackageHostedShortFormatWithVersionSpec,
     );

--- a/test/dependency_specs/hosted_package_dependency_spec_test.dart
+++ b/test/dependency_specs/hosted_package_dependency_spec_test.dart
@@ -184,6 +184,45 @@ void main() {
       });
     });
   });
+
+  group(
+      'given pubspec.yaml with dependency hosted in shot format with version spec',
+      () {
+    final pubspec = PubspecYaml.loadFromYamlString(
+      pubspecWithPackageHostedShortFormatWithVersionSpec,
+    );
+
+    group('$PubspecYaml.loadFromYamlString', () {
+      test('produces object with defined version', () {
+        expect(
+          pubspec.dependencies.first.iswitcho(
+            hosted: (p) => p.version.hasValue,
+            otherwise: () => false,
+          ),
+          isTrue,
+        );
+      });
+
+      test('produces object with correct version specification', () {
+        expect(
+          pubspec.dependencies.first.iswitcho(
+            hosted: (p) => p.version.valueOr(() => ''),
+            otherwise: () => '',
+          ),
+          version,
+        );
+      });
+    });
+
+    group('$PubspecYaml.toYamlString', () {
+      test('produces string equivalent to the input', () {
+        expect(
+          pubspec.toYamlString(),
+          pubspecWithPackageHostedShortFormatWithVersionSpec,
+        );
+      });
+    });
+  });
 }
 
 const dependency = 'transmogrify';
@@ -222,5 +261,14 @@ dependencies:
     hosted:
       name: $name
       url: $url
+    version: $version
+''';
+
+const pubspecWithPackageHostedShortFormatWithVersionSpec = '''
+name: pubspec_yaml
+
+dependencies:
+  $dependency:
+    hosted: $url
     version: $version
 ''';


### PR DESCRIPTION
Since Dart 2.15 we can define [hosted dependencies](https://dart.dev/tools/pub/dependencies#hosted-packages) like this:

```yaml
dependencies:
  transmogrify:
    hosted: https://some-package-server.com
    version: ^1.4.0
```

See #40 